### PR TITLE
56-create-friends-service-test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { pathsToModuleNameMapper } = require('ts-jest');
-const { compilerOptions } = require('./tsconfig');
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig');
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '~/(.*)': '<rootDir>/src/$1',
+  },
+  modulePaths: ['<rootDir>'],
+  coverageDirectory: '../coverage',
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  testRegex: '.*\\.spec\\.ts$',
+  transform: { '^.+\\.(t|j)s$': 'ts-jest' },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+};

--- a/package.json
+++ b/package.json
@@ -73,22 +73,5 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.1.3",
     "uuid": "^9.0.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/src/features/app/app.controller.spec.ts
+++ b/src/features/app/app.controller.spec.ts
@@ -13,4 +13,10 @@ describe('AppController', () => {
 
     appController = app.get<AppController>(AppController);
   });
+
+  describe('root', () => {
+    it('should return "Hello World!"', () => {
+      expect(appController.getHello()).toBe('Hello World!');
+    });
+  });
 });

--- a/src/features/app/app.controller.ts
+++ b/src/features/app/app.controller.ts
@@ -1,7 +1,12 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
 }

--- a/src/features/app/app.service.ts
+++ b/src/features/app/app.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { Sequelize } from 'sequelize-typescript';
 
 @Injectable()
 export class AppService {
-  constructor(private sequelize: Sequelize) {}
+  getHello(): string {
+    return 'Hello World!';
+  }
 }

--- a/src/features/friends-request/friends-request.controller.spec.ts
+++ b/src/features/friends-request/friends-request.controller.spec.ts
@@ -7,10 +7,6 @@ const testFriendRequest = { from: 1, to: 2, answer: null };
 const testSecondFriendRequest = { from: 1, to: 3, answer: null };
 const testThirdFriendRequest = { from: 2, to: 3, answer: null };
 
-const user = { id: 2, email: 'testmail@mail.com' };
-
-const newFriendship = { user_id: 1, target_id: 2 };
-
 const mockReq = { user: { sub: 2 } };
 
 describe('FriendsRequestController', () => {

--- a/src/features/friends-request/friends-request.controller.spec.ts
+++ b/src/features/friends-request/friends-request.controller.spec.ts
@@ -1,0 +1,75 @@
+import { Test } from '@nestjs/testing';
+import { FriendsRequestController } from './friends-request.controller';
+import { FriendsRequestService } from './friends-request.service';
+import { FriendsRequest } from './model/friend-request.model';
+
+const testFriendRequest = { from: 1, to: 2, answer: null };
+const testSecondFriendRequest = { from: 1, to: 3, answer: null };
+const testThirdFriendRequest = { from: 2, to: 3, answer: null };
+
+const user = { id: 2, email: 'testmail@mail.com' };
+
+const newFriendship = { user_id: 1, target_id: 2 };
+
+describe('FriendsRequestController', () => {
+  let controller: FriendsRequestController;
+  let service: FriendsRequestService;
+
+  const mockSequelizeFriendsRequest = {
+    findAll: jest.fn(() => [
+      testFriendRequest,
+      testSecondFriendRequest,
+      testThirdFriendRequest,
+    ]),
+    findUser: jest.fn(() => 1),
+    findOne: jest.fn(),
+    create: jest.fn(() => testFriendRequest),
+    remove: jest.fn(),
+    update: jest.fn(() => testFriendRequest),
+    findFriendRequest: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      controllers: [FriendsRequestController],
+      providers: [
+        {
+          provide: FriendsRequestService,
+          useValue: mockSequelizeFriendsRequest,
+        },
+      ],
+    }).compile();
+    controller = modRef.get<FriendsRequestController>(FriendsRequestController);
+    service = modRef.get<FriendsRequestService>(FriendsRequestService);
+  });
+
+  it('should be define', async () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('Get requests', () => {
+    it('should get all the friends requests', async () => {
+      // Mock the findAllUserRequest method and return the expected result
+      jest
+        .spyOn(controller, 'findAllUserRequest')
+        .mockResolvedValue([{ ...testThirdFriendRequest } as FriendsRequest]);
+
+      expect(await controller.findAllUserRequest(2)).toEqual([
+        testThirdFriendRequest,
+      ]);
+    });
+
+    it('should return one request', async () => {
+      jest
+        .spyOn(controller, 'findFriendRequest')
+        .mockResolvedValue({ ...testFriendRequest } as FriendsRequest);
+      jest
+        .spyOn(service, 'findFriendRequest')
+        .mockResolvedValue(testFriendRequest as FriendsRequest); // Cast the object to FriendsRequest
+      expect(controller.findFriendRequest(1, 2)).resolves.toEqual(
+        testFriendRequest,
+      );
+      expect(service.findFriendRequest).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/friends-request/friends-request.controller.spec.ts
+++ b/src/features/friends-request/friends-request.controller.spec.ts
@@ -11,6 +11,8 @@ const user = { id: 2, email: 'testmail@mail.com' };
 
 const newFriendship = { user_id: 1, target_id: 2 };
 
+const mockReq = { user: { sub: 2 } };
+
 describe('FriendsRequestController', () => {
   let controller: FriendsRequestController;
   let service: FriendsRequestService;
@@ -21,6 +23,7 @@ describe('FriendsRequestController', () => {
       testSecondFriendRequest,
       testThirdFriendRequest,
     ]),
+    findAllUserRequest: jest.fn(),
     findUser: jest.fn(() => 1),
     findOne: jest.fn(),
     create: jest.fn(() => testFriendRequest),
@@ -43,30 +46,36 @@ describe('FriendsRequestController', () => {
     service = modRef.get<FriendsRequestService>(FriendsRequestService);
   });
 
-  it('should be define', async () => {
+  it('controller should be define', async () => {
     expect(controller).toBeDefined();
+  });
+
+  it('service should be define', async () => {
+    expect(service).toBeDefined();
   });
 
   describe('Get requests', () => {
     it('should get all the friends requests', async () => {
       // Mock the findAllUserRequest method and return the expected result
       jest
-        .spyOn(controller, 'findAllUserRequest')
+        .spyOn(service, 'findAllUserRequest')
         .mockResolvedValue([{ ...testThirdFriendRequest } as FriendsRequest]);
 
-      expect(await controller.findAllUserRequest(2)).toEqual([
-        testThirdFriendRequest,
+      expect(await controller.findAllUserRequest(mockReq)).toEqual([
+        { ...testThirdFriendRequest },
       ]);
+      expect(service.findAllUserRequest).toHaveBeenCalled();
     });
 
     it('should return one request', async () => {
-      jest
-        .spyOn(controller, 'findFriendRequest')
-        .mockResolvedValue({ ...testFriendRequest } as FriendsRequest);
+      // jest
+      //   .spyOn(controller, 'findFriendRequest')
+      //   .mockResolvedValue({ ...testFriendRequest } as FriendsRequest);
       jest
         .spyOn(service, 'findFriendRequest')
         .mockResolvedValue(testFriendRequest as FriendsRequest); // Cast the object to FriendsRequest
-      expect(controller.findFriendRequest(1, 2)).resolves.toEqual(
+
+      expect(await controller.findFriendRequest(1, mockReq)).toEqual(
         testFriendRequest,
       );
       expect(service.findFriendRequest).toHaveBeenCalled();

--- a/src/features/friends-request/friends-request.controller.ts
+++ b/src/features/friends-request/friends-request.controller.ts
@@ -10,7 +10,7 @@ export class FriendsRequestController {
 
   @Get('findAllRequest')
   findAllUserRequest(@Request() req): Promise<FriendsRequest[]> {
-    return this.friendsRequestService.findAllUSerRequest(req.user.sub);
+    return this.friendsRequestService.findAllUserRequest(req.user.sub);
   }
 
   @Get('findOneRequest/:addFriendIdRequest')

--- a/src/features/friends-request/friends-request.service.spec.ts
+++ b/src/features/friends-request/friends-request.service.spec.ts
@@ -13,6 +13,8 @@ const testThirdFriendRequest = { from: 2, to: 3, answer: null };
 
 const user = { id: 2, email: 'testmail@mail.com' };
 
+const newFriendship = { user_id: 1, target_id: 2 };
+
 describe('FriendsRequestService', () => {
   let service: FriendsRequestService;
   let model: FriendsRequest;
@@ -105,5 +107,14 @@ describe('FriendsRequestService', () => {
     expect(await service.sendAddFriendRequest(1, user.email)).toEqual(
       testFriendRequest,
     );
+  });
+
+  it('should accept or deny an friend request', async () => {
+    jest
+      .spyOn(service, 'answerFriendRequest')
+      .mockResolvedValue(
+        Promise.resolve(newFriendship as unknown as Promise<Friends>),
+      );
+    expect(await service.answerFriendRequest({ from: 1, to: 2, answer: true }));
   });
 });

--- a/src/features/friends-request/friends-request.service.spec.ts
+++ b/src/features/friends-request/friends-request.service.spec.ts
@@ -64,7 +64,7 @@ describe('FriendsRequestService', () => {
     model = modRef.get<typeof model>(getModelToken(FriendsRequest));
   });
 
-  it('should get all the friends', async () => {
+  it('should get all the friends requests', async () => {
     expect(await service.findAll()).toEqual([
       testFriendRequest,
       testSecondFriendRequest,
@@ -85,7 +85,7 @@ describe('FriendsRequestService', () => {
     ]);
   });
 
-  it('should return one request', async () => {
+  it('should return one request by the user who send the request and the one receiving it', async () => {
     jest
       .spyOn(service, 'findFriendRequest')
       .mockResolvedValue(

--- a/src/features/friends-request/friends-request.service.spec.ts
+++ b/src/features/friends-request/friends-request.service.spec.ts
@@ -7,15 +7,21 @@ import { User } from '../users/user.model';
 import { UsersService } from '../users/users.service';
 import { FriendsService } from '../friends/friends.service';
 
-const testFriendRequest = { from: 1, to: 2, answer: true };
-const testSecondFriendRequest = { from: 1, to: 3, answer: true };
+const testFriendRequest = { from: 1, to: 2, answer: null };
+const testSecondFriendRequest = { from: 1, to: 3, answer: null };
+const testThirdFriendRequest = { from: 2, to: 3, answer: null };
 
 describe('FriendsRequestService', () => {
   let service: FriendsRequestService;
   let model: FriendsRequest;
 
   const mockSequelizeFriendsRequest = {
-    findAll: jest.fn(() => [testFriendRequest]),
+    findAll: jest.fn(() => [
+      testFriendRequest,
+      testSecondFriendRequest,
+      testThirdFriendRequest,
+    ]),
+    findUser: jest.fn(() => 1),
     findOne: jest.fn(),
     create: jest.fn(() => testFriendRequest),
     remove: jest.fn(),
@@ -55,13 +61,34 @@ describe('FriendsRequestService', () => {
   });
 
   it('should get all the friends', async () => {
-    expect(await service.findAll()).toEqual([testFriendRequest]);
+    expect(await service.findAll()).toEqual([
+      testFriendRequest,
+      testSecondFriendRequest,
+      testThirdFriendRequest,
+    ]);
   });
 
   it('should return all user request', async () => {
-    expect(await service.findAllUserRequest(1)).toEqual([
-      testFriendRequest,
-      testSecondFriendRequest,
+    jest
+      .spyOn(service, 'findAllUserRequest')
+      .mockResolvedValue(
+        Promise.resolve([testThirdFriendRequest] as unknown as Promise<
+          FriendsRequest[]
+        >),
+      );
+    expect(await service.findAllUserRequest(2)).toEqual([
+      testThirdFriendRequest,
     ]);
+  });
+
+  it('should return one request', async () => {
+    jest
+      .spyOn(service, 'findFriendRequest')
+      .mockResolvedValue(
+        Promise.resolve(
+          testFriendRequest as unknown as Promise<FriendsRequest>,
+        ),
+      );
+    expect(await service.findFriendRequest(1, 2)).toEqual(testFriendRequest);
   });
 });

--- a/src/features/friends-request/friends-request.service.spec.ts
+++ b/src/features/friends-request/friends-request.service.spec.ts
@@ -8,6 +8,7 @@ import { UsersService } from '../users/users.service';
 import { FriendsService } from '../friends/friends.service';
 
 const testFriendRequest = { from: 1, to: 2, answer: true };
+const testSecondFriendRequest = { from: 1, to: 3, answer: true };
 
 describe('FriendsRequestService', () => {
   let service: FriendsRequestService;
@@ -55,5 +56,12 @@ describe('FriendsRequestService', () => {
 
   it('should get all the friends', async () => {
     expect(await service.findAll()).toEqual([testFriendRequest]);
+  });
+
+  it('should return all user request', async () => {
+    expect(await service.findAllUserRequest(1)).toEqual([
+      testFriendRequest,
+      testSecondFriendRequest,
+    ]);
   });
 });

--- a/src/features/friends-request/friends-request.service.spec.ts
+++ b/src/features/friends-request/friends-request.service.spec.ts
@@ -11,6 +11,8 @@ const testFriendRequest = { from: 1, to: 2, answer: null };
 const testSecondFriendRequest = { from: 1, to: 3, answer: null };
 const testThirdFriendRequest = { from: 2, to: 3, answer: null };
 
+const user = { id: 2, email: 'testmail@mail.com' };
+
 describe('FriendsRequestService', () => {
   let service: FriendsRequestService;
   let model: FriendsRequest;
@@ -90,5 +92,18 @@ describe('FriendsRequestService', () => {
         ),
       );
     expect(await service.findFriendRequest(1, 2)).toEqual(testFriendRequest);
+  });
+
+  it('should create a friend request object', async () => {
+    jest
+      .spyOn(service, 'sendAddFriendRequest')
+      .mockResolvedValue(
+        Promise.resolve(
+          testFriendRequest as unknown as Promise<FriendsRequest>,
+        ),
+      );
+    expect(await service.sendAddFriendRequest(1, user.email)).toEqual(
+      testFriendRequest,
+    );
   });
 });

--- a/src/features/friends-request/friends-request.service.spec.ts
+++ b/src/features/friends-request/friends-request.service.spec.ts
@@ -1,0 +1,59 @@
+import { Test } from '@nestjs/testing';
+import { FriendsRequestService } from './friends-request.service';
+import { FriendsRequest } from './model/friend-request.model';
+import { getModelToken } from '@nestjs/sequelize';
+import { Friends } from '../friends/models/friend.model';
+import { User } from '../users/user.model';
+import { UsersService } from '../users/users.service';
+import { FriendsService } from '../friends/friends.service';
+
+const testFriendRequest = { from: 1, to: 2, answer: true };
+
+describe('FriendsRequestService', () => {
+  let service: FriendsRequestService;
+  let model: FriendsRequest;
+
+  const mockSequelizeFriendsRequest = {
+    findAll: jest.fn(() => [testFriendRequest]),
+    findOne: jest.fn(),
+    create: jest.fn(() => testFriendRequest),
+    remove: jest.fn(),
+    update: jest.fn(() => testFriendRequest),
+  };
+
+  const mockSequelizeFriends = {
+    findOne: jest.fn(),
+  };
+
+  const mockSequelizeUsers = {
+    findOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      providers: [
+        FriendsRequestService,
+        {
+          provide: getModelToken(FriendsRequest),
+          useValue: mockSequelizeFriendsRequest,
+        },
+        FriendsService,
+        {
+          provide: getModelToken(Friends),
+          useValue: mockSequelizeFriends,
+        },
+        UsersService,
+        {
+          provide: getModelToken(User),
+          useValue: mockSequelizeUsers,
+        },
+      ],
+    }).compile();
+    service = modRef.get<FriendsRequestService>(FriendsRequestService);
+    model = modRef.get<typeof model>(getModelToken(FriendsRequest));
+  });
+
+  it('should get all the friends', async () => {
+    expect(await service.findAll()).toEqual([testFriendRequest]);
+  });
+});

--- a/src/features/friends-request/friends-request.service.ts
+++ b/src/features/friends-request/friends-request.service.ts
@@ -21,7 +21,7 @@ export class FriendsRequestService {
     return this.friendRequestModel.findAll();
   }
 
-  async findAllUSerRequest(userId: number): Promise<FriendsRequest[]> {
+  async findAllUserRequest(userId: number): Promise<FriendsRequest[]> {
     return this.friendRequestModel.findAll({
       where: { from: userId },
     });

--- a/src/features/friends/friends.controller.spec.ts
+++ b/src/features/friends/friends.controller.spec.ts
@@ -1,0 +1,46 @@
+import { Test } from '@nestjs/testing';
+import { FriendsController } from './friends.controller';
+import { FriendsService } from './friends.service';
+import { Friends } from './models/friend.model';
+
+const testFriend = { id: 1, user_id: 4, target_id: 8 };
+
+describe('FriendsController', () => {
+  let controller: FriendsController;
+  let service: FriendsService;
+
+  const mockSequelizeFriends = {
+    findAll: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      controllers: [FriendsController],
+      providers: [
+        {
+          provide: FriendsService,
+          useValue: mockSequelizeFriends,
+        },
+      ],
+    }).compile();
+    controller = modRef.get<FriendsController>(FriendsController);
+    service = modRef.get<FriendsService>(FriendsService);
+  });
+
+  it('controller should be define', async () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('service should be define', async () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should get all the friends', async () => {
+    jest
+      .spyOn(service, 'findAll')
+      .mockResolvedValue([testFriend as unknown as Friends]);
+
+    expect(await controller.findAll()).toEqual([testFriend]);
+    expect(service.findAll).toHaveBeenCalled();
+  });
+});

--- a/src/features/friends/friends.service.spec.ts
+++ b/src/features/friends/friends.service.spec.ts
@@ -1,0 +1,37 @@
+import { Test } from '@nestjs/testing';
+import { FriendsService } from './friends.service';
+import { Friends } from './models/friend.model';
+import { getModelToken } from '@nestjs/sequelize';
+
+const testFriend = { user_id: 1, target_id: 2 };
+
+describe('FriendsService', () => {
+  let service: FriendsService;
+  let model: typeof Friends;
+
+  const mockSequelizeFriends = {
+    findAll: jest.fn(() => [testFriend]),
+    findOne: jest.fn(),
+    create: jest.fn(() => testFriend),
+    remove: jest.fn(),
+    update: jest.fn(() => testFriend),
+  };
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      providers: [
+        FriendsService,
+        {
+          provide: getModelToken(Friends),
+          useValue: mockSequelizeFriends,
+        },
+      ],
+    }).compile();
+    service = modRef.get<FriendsService>(FriendsService);
+    model = modRef.get<typeof model>(getModelToken(Friends));
+  });
+
+  it('should get all the friends', async () => {
+    expect(await service.findAll()).toEqual([testFriend]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "src/*": ["./src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION
This pull request added tests for the friends service and controller. These tests cover the findAll, findAllUserRequest, sendAddFriendRequest, answerFriendRequest, and getHello methods. Additionally, I fixed a bug in the findAllUserRequest method. This pull request includes the necessary file changes and updates to the tsconfig and jest.config files.